### PR TITLE
Adding html5shim for IE<8.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="utf-8">
     <title>My Favorite Beer, a BrowserID example</title>
+    <!--[if lt IE 9]>
+    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
     <link href='http://fonts.googleapis.com/css?family=Special+Elite&v1' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Shadows+Into+Light&v1' rel='stylesheet' type='text/css'>
     <link rel="stylesheet/less" type="text/css" href="style.less">

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,10 +1,3 @@
-// IE needs this to be able to style HTML5 elements properly
-var els = ['header'|'footer'|'small'];
-for(var type, i = 0; type=els[i]; ++i) {
-  document.createElement(els);
-}
-
-
 function setSessions(val) {
   if (navigator.id) {
     navigator.id.sessions = val ? val : [ ];


### PR DESCRIPTION
Only included for IE<8.

This fixes some display bugs in IE8 when using HTML5 elements.
