### PR TITLE
Remove the border on the logo in the footer for IE

### DIFF
--- a/static/style.less
+++ b/static/style.less
@@ -155,6 +155,7 @@ footer {
         text-align: center;
         img {
             margin-bottom: -.5em;
+            border:none;
         }
         font-weight: 200;
     }


### PR DESCRIPTION
This pull request adds a border: none to the browserid image in the footer.  The image was showing a border in Internet Explorer 9.

close #36
