### PR TITLE
Closes #44: Multiple calls to getVerifiedEmail after canceling sign-in

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -18,7 +18,6 @@ function loggedIn(email, immediate) {
     .append($("<span>").text(email).addClass("username"))
     .append($("<span>!</span>"));
   l.append($('<div><a id="logout" href="#" >(logout)</a></div>'));
-  l.unbind('click');
   
   $("#logout").bind('click', logout);
 
@@ -93,7 +92,7 @@ function loggedOut() {
   $("header .picture").empty();
   var l = $("header .login").removeClass('clickable');
   l.html('<img src="i/sign_in_blue.png" alt="Sign in">')
-    .show().click(function() {
+    .show().one('click', function() {
       $("header .login").css('opacity', '0.5');
       navigator.id.getVerifiedEmail(gotVerifiedEmail);
     }).addClass("clickable").css('opacity','1.0');


### PR DESCRIPTION
Only handle one sign-in click instead of binding then conditionally unbinding on success.
