### PR TITLE
Change link to My FavouriteSandwich to be http

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ should run under the hosting environment of your preference.
 
 ## Credit
 
-Concept + Design(kinda): https://myfavouritesandwich.org/
+Concept + Design(kinda): http://myfavouritesandwich.org/
 Art:                     http://www.flickr.com/photos/bitzi/236037776/

--- a/static/index.html
+++ b/static/index.html
@@ -62,7 +62,7 @@
 
         <small>
           (Thanks to <a href="http://www.flickr.com/photos/bitzi/236037776/">@bitzi for the photo</a>,
-          and the <a href="https://myfavouritesandwich.org">unhosted dudes for the concept</a>)
+          and the <a href="http://myfavouritesandwich.org">unhosted dudes for the concept</a>)
         </small>
 
       </div>


### PR DESCRIPTION
Hi Lloyd,

We want to move My Favourite Sandwich to an s3 website bucket, and they don't support https. And since most of the traffic probably comes from this link, we would be very thankful if you could change it to http!

Thanks a bundle,
Michiel.
