### PR TITLE
Remove trailing semi which blows up IE6 and IE7

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,7 +1,7 @@
 var browseridArguments = {
   // display our tos and privacy policy in the browserid dialog
   privacyURL: '/privacy.html',
-  tosURL: '/tos.html',
+  tosURL: '/tos.html'
 };
 
 function setSessions(val) {


### PR DESCRIPTION
browserid issue #1390
