### PR TITLE
fix domain used for ephemeral builds

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -89,7 +89,7 @@ function determineBrowserIDURL(req) {
 
   var e = determineEnvironment(req);
   if (staticEnvs[e]) return staticEnvs[e];
-  else return 'https://' + e + '.hacksign.in';
+  else return 'https://' + e + '.personatest.org';
 }
 
 function determineBrowserIDHost(req) {


### PR DESCRIPTION
I think? this should fix the bug @ozten opened against browserid: https://github.com/mozilla/browserid/issues/1984
