### PR TITLE
fix the 500 for api/get when an authed user has chosen no beer; allow setting beer to the empty string

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -55,7 +55,8 @@ exports.get = function(collection, email, cb) {
   var c = collections[collection].find({ email: email }, { beer: 1 });
   c.toArray(function(err, docs) {
     if (err) return cb(err);
-    if (docs.length != 1) return cb("consistency error!  more than one doc returned!");
+    if (docs.length > 1) return cb("consistency error!  more than one doc returned!");
+    if (docs.length === 0) return cb(undefined, '');
     cb(undefined, docs[0].beer);
   });
 };

--- a/server/main.js
+++ b/server/main.js
@@ -268,7 +268,7 @@ app.post("/api/set", function (req, res) {
 
   var beer = req.body.beer;
 
-  if (!beer) {
+  if (typeof beer === 'undefined') {
     res.writeHead(400, {"Content-Type": "text/plain"});
     res.write("Bad Request: a 'beer' parameter is required to set your favorite beer");
     res.end();


### PR DESCRIPTION
fixes GH-47, which is long standing (harmless but noisy in network traces) annoyance.
